### PR TITLE
Make `AndroidNativeDecoder` working again

### DIFF
--- a/app/src/main/java/xyz/gianlu/librespot/android/LibrespotApp.java
+++ b/app/src/main/java/xyz/gianlu/librespot/android/LibrespotApp.java
@@ -13,8 +13,8 @@ public final class LibrespotApp extends Application {
     private static final String TAG = LibrespotApp.class.getSimpleName();
 
     static {
-        Decoders.registerDecoder(SuperAudioFormat.VORBIS, AndroidNativeDecoder.class);
-        Decoders.registerDecoder(SuperAudioFormat.MP3, AndroidNativeDecoder.class);
+        Decoders.registerDecoder(SuperAudioFormat.VORBIS, 0, AndroidNativeDecoder.class);
+        Decoders.registerDecoder(SuperAudioFormat.MP3, 0, AndroidNativeDecoder.class);
 
         if (isArm()) {
             Decoders.registerDecoder(SuperAudioFormat.VORBIS, 0, TremoloVorbisDecoder.class);

--- a/librespot-android-decoder/src/main/java/xyz/gianlu/librespot/player/decoders/AndroidNativeDecoder.java
+++ b/librespot-android-decoder/src/main/java/xyz/gianlu/librespot/player/decoders/AndroidNativeDecoder.java
@@ -28,17 +28,18 @@ public final class AndroidNativeDecoder extends Decoder {
     public AndroidNativeDecoder(@NotNull SeekableInputStream audioIn, float normalizationFactor, int duration) throws IOException, DecoderException {
         super(audioIn, normalizationFactor, duration);
 
+        int start = audioIn.position();
         extractor = new MediaExtractor();
         extractor.setDataSource(new MediaDataSource() {
             @Override
             public int readAt(long position, byte[] buffer, int offset, int size) throws IOException {
-                audioIn.seek((int) position);
+                audioIn.seek((int) position + start);
                 return audioIn.read(buffer, offset, size);
             }
 
             @Override
             public long getSize() {
-                return audioIn.size();
+                return audioIn.size() - start;
             }
 
             @Override

--- a/librespot-android-decoder/src/main/java/xyz/gianlu/librespot/player/decoders/AndroidNativeDecoder.java
+++ b/librespot-android-decoder/src/main/java/xyz/gianlu/librespot/player/decoders/AndroidNativeDecoder.java
@@ -93,12 +93,11 @@ public final class AndroidNativeDecoder extends Decoder {
                         codec.signalEndOfInputStream();
                         return -1;
                     }
-
                     codec.queueInputBuffer(inputBufferId, inputBuffer.position(), inputBuffer.limit(), extractor.getSampleTime(), 0);
                     extractor.advance();
                 }
 
-                int outputBufferId = codec.dequeueOutputBuffer(info, -1);
+                int outputBufferId = codec.dequeueOutputBuffer(info, 10000);
                 if (outputBufferId >= 0) {
                     ByteBuffer outputBuffer = codec.getOutputBuffer(outputBufferId);
 
@@ -111,6 +110,8 @@ public final class AndroidNativeDecoder extends Decoder {
                     codec.releaseOutputBuffer(outputBufferId, false);
                     presentationTime = TimeUnit.MICROSECONDS.toMillis(info.presentationTimeUs);
                     return info.size;
+                } else if (outputBufferId == MediaCodec.INFO_TRY_AGAIN_LATER) {
+                    Log.d(TAG, "Timeout");
                 } else if (outputBufferId == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
                     Log.d(TAG, "Output buffers changed");
                 } else if (outputBufferId == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {


### PR DESCRIPTION
Hey, first of all many thanks for this great library and demo! :)
I created this PR, because I had some trouble to get the library working in my music player app, so I was interested in the `AndroidNativeDecoder` and also encountered some issues.

First, after making sure the app does not use the tremolo decoder for ogg decoding on arm devices, the app prefers the build-in decoders over the `AndroidNativeDecoder`, so I changed the register part to add them to the front of the list of decoders.

Then, when the `AndroidNativeDecoder` is being used, I always encountered `DecoderException: No tracks found.`, but interestingly it worked when writing the full stream into a buffer and reading out of it instead. Then I realized the stream is not at position zero when passed to the decoder, so I added the starting position as offset in `MediaDataSource` to get the `MediaExtractor` working again.

Lastly, the `dequeueOutputBuffer` blocks indefinitely for me, but I could get it working by specifying a timeout.

With these changes, the decoder works great again on my Pixel 6!